### PR TITLE
Fix the Palestinian flag

### DIFF
--- a/flags/svg/PS.svg
+++ b/flags/svg/PS.svg
@@ -4,8 +4,8 @@
   </mask>
   <g mask="url(#a)" fill-rule="evenodd" clip-rule="evenodd">
     <path d="M0 0h32v24H0V0z" fill="#F7FCFF"/>
-    <path d="M0 0v8h32V0H0z" fill="#5EAA22"/>
-    <path d="M0 16v8h32v-8H0z" fill="#272727"/>
+    <path d="M0 0v8h32V0H0z" fill="#272727"/>
+    <path d="M0 16v8h32v-8H0z" fill="#5EAA22"/>
     <path d="M0 2l16 10L0 22V2z" fill="#E31D1C"/>
   </g>
 </svg>


### PR DESCRIPTION
Corrected the order of the green and black stripes in the Palestinian flag to the right sequence

![Flag_of_Palestine svg](https://github.com/raramuridesign/mysql-country-list/assets/13188008/f8b4602f-dd35-4c22-ad44-7cf3a25e8bcb)
Source:  [Wikipedia](https://en.wikipedia.org/wiki/State_of_Palestine)